### PR TITLE
fix: publish must return object

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,7 @@ async function publish(pluginConfig, context) {
     await preparePod(pluginConfig, context);
   }
 
-  await publishPod(pluginConfig, context);
-
-  return true;
+  return publishPod(pluginConfig, context);
 }
 
 module.exports = {verifyConditions, prepare, publish};

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -18,4 +18,6 @@ module.exports = async (pluginConfig, context) => {
   await result;
 
   logger.log(`Published ${version} to cocoapods!`);
+
+  return {version};
 };


### PR DESCRIPTION
Semantic-release requires that the publish function returns an object